### PR TITLE
Add placeholder bibliography for Jekyll

### DIFF
--- a/_bibliography/bibliography.bib
+++ b/_bibliography/bibliography.bib
@@ -1,0 +1,6 @@
+@article{example,
+  title={Example Article},
+  author={Doe, John},
+  journal={Journal of Examples},
+  year={2023}
+}

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,0 +1,6 @@
+@article{example,
+  title={Example Article},
+  author={Doe, John},
+  journal={Journal of Examples},
+  year={2023}
+}

--- a/blog/_bibliography/bibliography.bib
+++ b/blog/_bibliography/bibliography.bib
@@ -1,0 +1,6 @@
+@article{example,
+  title={Example Article},
+  author={Doe, John},
+  journal={Journal of Examples},
+  year={2023}
+}


### PR DESCRIPTION
## Summary
- provide example `bibliography.bib` for the jekyll-scholar plugin
- remove placeholder file and create actual `_bibliography` directories

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403)*

------
https://chatgpt.com/codex/tasks/task_e_687cacf7ddb88329a1c1a33580230784