### PR TITLE
Remove jekyll-katex plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,6 @@ permalink: /blog/:year/:month/:day/:title/
 plugins:
   - jekyll-feed
   - jekyll-sitemap
-  - jekyll-katex
   - jekyll-scholar
 
 # Kramdown math settings

--- a/blog/Gemfile
+++ b/blog/Gemfile
@@ -18,7 +18,6 @@ group :jekyll_plugins do
 	gem "jekyll-scholar"
 	gem "jekyll-sitemap"
 	gem "jekyll-feed"
-	gem "jekyll-katex"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/blog/Gemfile.lock
+++ b/blog/Gemfile.lock
@@ -43,9 +43,6 @@ GEM
       terminal-table (~> 1.8)
     jekyll-feed (0.13.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-katex (1.0.0)
-      execjs (~> 2.7)
-      jekyll (>= 3.6, < 5.0)
     jekyll-sass-converter (2.0.1)
       sassc (> 2.0.1, < 3.0)
     jekyll-scholar (6.5.1)
@@ -103,7 +100,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-feed
-  jekyll-katex
   jekyll-scholar
   jekyll-sitemap
   minima (~> 2.5)

--- a/blog/_config.yml
+++ b/blog/_config.yml
@@ -6,13 +6,6 @@ plugins:
   - jekyll-scholar
   - jekyll-sitemap
   - jekyll-feed
-  - jekyll-katex
-katex:
-  js_path: "assets"  # Path used to search for katex.min.js
-  rendering_options:
-    # Default KaTeX rendering options. See https://github.com/Khan/KaTeX#rendering-options
-    throw_error: false      # throwOnError - set to false if you want rendering to output error as text rather than a build error
-    error_color: "#cc0000"  # errorColor
 
 baseurl: "/blog"         # so everything’s served under /blog
 permalink: /blog/:year/:month/:day/:title/


### PR DESCRIPTION
## Summary
- drop `jekyll-katex` from the plugin list
- clean plugin references from blog config and gem files

## Testing
- `bundle install` *(fails: 403 Forbidden due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687cafb3ac608329abbe02bf3485275b