### PR TITLE
Remove katexmm wrappers from blog index

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -44,9 +44,7 @@ title: blog
                 <div class='post-row'>
                     <p class='post-title'>
                         <a href="{{ post.url }}">
-                            {% katexmm %}
                             {{ post.title }}
-                            {% endkatexmm %}
                         </a>
                     </p>
                     <p class='post-date'>
@@ -54,9 +52,7 @@ title: blog
                     </p>
                 </div>
                 <p class='post-subtitle'>
-                    {% katexmm %}
                     {{ post.subtitle }}
-                    {% endkatexmm %}
                 </p>
                 <span class='hidden'>{{ forloop.index }}</span>
             {% endfor %}


### PR DESCRIPTION
## Summary
- clean Liquid katex tags from `blog/index.html`

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687cafb2c7648329a18d81db8cefb08f