### PR TITLE
Remove jekyll-scholar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,17 +27,11 @@ permalink: /blog/:year/:month/:day/:title/
 plugins:
   - jekyll-feed
   - jekyll-sitemap
-  - jekyll-scholar
 
 # Kramdown math settings
 kramdown:
   input: GFM
   math_engine: katex
-
-# jekyll-scholar bibliography
-scholar:
-  style: apa
-  bibliography: bibliography.bib
 
 # Optional: default layout for blog posts
 defaults:

--- a/blog/Gemfile
+++ b/blog/Gemfile
@@ -15,7 +15,6 @@ gem "minima", "~> 2.5"
 # gem "github-pages", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-	gem "jekyll-scholar"
 	gem "jekyll-sitemap"
 	gem "jekyll-feed"
 end

--- a/blog/Gemfile.lock
+++ b/blog/Gemfile.lock
@@ -3,19 +3,8 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    bibtex-ruby (5.1.4)
-      latex-decode (~> 0.0)
-    citeproc (1.0.10)
-      namae (~> 1.0)
-    citeproc-ruby (1.1.10)
-      citeproc (~> 1.0, >= 1.0.9)
-      csl (~> 1.5)
     colorator (1.1.0)
     concurrent-ruby (1.1.5)
-    csl (1.5.1)
-      namae (~> 1.0)
-    csl-styles (1.0.1.10)
-      csl (~> 1.0)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -45,11 +34,6 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (2.0.1)
       sassc (> 2.0.1, < 3.0)
-    jekyll-scholar (6.5.1)
-      bibtex-ruby (~> 5.1.0)
-      citeproc-ruby (~> 1.0)
-      csl-styles (~> 1.0)
-      jekyll (~> 4.0)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
     jekyll-sitemap (1.4.0)
@@ -60,7 +44,6 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    latex-decode (0.3.1)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -70,7 +53,6 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    namae (1.0.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
@@ -100,7 +82,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-feed
-  jekyll-scholar
   jekyll-sitemap
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/blog/_config.yml
+++ b/blog/_config.yml
@@ -3,16 +3,11 @@ permalink: /blog/:year/:month/:day/:title/
 environment: prod
 url: "m6li.com"  # Sitemap base URL.
 plugins:
-  - jekyll-scholar
   - jekyll-sitemap
   - jekyll-feed
 
 baseurl: "/blog"         # so everything’s served under /blog
 permalink: /blog/:year/:month/:day/:title/
-
-scholar:
-style: apa
-bibliography: bibliography.bib
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
## Summary
- remove `jekyll-scholar` from the main configuration
- remove scholar settings in blog config
- remove `jekyll-scholar` gem dependency and update lock file

## Testing
- `bundle update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687cc2a567c4832981f882ef81ece517