### PR TITLE
Fix art.pdf link quoting

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                 <li><a href="https://www.imperial.ac.uk/mathematics/postgraduate/doctoral-programme/current-students/the-doris-chen-phd-award/mobilityfund/">Doris-Chen Mobility Award (2024)</a> – £1000 awarded to exceptional Math PhD students at Imperial College</li>
                 <li><a href="https://www.imperial.ac.uk/mathematics/postgraduate/doctoral-programme/prospective-students/phd-funding-opportunities/">Roth Scholarship (2022)</a> – Full scholarship covering living costs and a stipend during PhD research</li>
                 <li>MSc Award (2021) – Prize for the best MSc Pure Mathematics presentation at Imperial College</li>
-                <li><a href="data/art.pdf"">Math Art Competition Runner Up (2020)</a> – 2nd place in a Math-themed art competition at King’s College London</li>
+                <li><a href="data/art.pdf">Math Art Competition Runner Up (2020)</a> – 2nd place in a Math-themed art competition at King’s College London</li>
               </ul>
             </td></tr>
           </tbody></table>


### PR DESCRIPTION
## Summary
- remove stray quote in `data/art.pdf` anchor tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cd5460e248329a8fc4dcfcac17085