### PR TITLE
Fix favicon path

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -25,7 +25,7 @@ title: blog
     '>
     <meta name='author' content='Gregory Gundersen'>
 
-    <link rel='shortcut icon' href='/favicon.png?v=e' />
+    <link rel='shortcut icon' href='/images/profile.jpg' />
     <link href='/css/blog.css' rel='stylesheet'/>
 
     {% include mathjax.html %}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
     <meta name="author" content="Muhammed Ali Mehmood">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="images/favicon/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/profile.jpg" type="image/jpeg">
     <link rel="stylesheet" type="text/css" href="stylesheet.css">
   </head>
 


### PR DESCRIPTION
## Summary
- update favicon links in `index.html` and `blog/index.html` to use the existing profile image

## Testing
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/images/profile.jpg`
- `curl -s http://localhost:8000/index.html | grep -n 'shortcut icon'`
- `curl -s http://localhost:8000/blog/index.html | grep -n 'shortcut icon'`


------
https://chatgpt.com/codex/tasks/task_e_687cd54657308329ba6cd25c1f69f608