### PR TITLE
Fix post order on blog index

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -38,7 +38,8 @@ title: blog
             </div>
         </div>
         <div id='posts' class='section'>
-            {% for post in site.posts %}
+            {% assign sorted_posts = site.posts | sort: 'date' | reverse %}
+            {% for post in sorted_posts %}
                 <div class='post-row'>
                     <p class='post-title'>
                         <a href="{{ post.url }}">


### PR DESCRIPTION
## Summary
- sort posts by date descending on blog index

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687cfe5138c88329b4032047b122d0ef